### PR TITLE
Refactor to use account codes

### DIFF
--- a/lib/handlers/getBalance.js
+++ b/lib/handlers/getBalance.js
@@ -4,12 +4,17 @@
  * GET: /books/{bookId}/balance
  * 
  * query:
- *   account {string} The account to get the balance for.
+ *   account {string} The account name to get the balance for.
+ *   accountCode {string} The account code to get the balance for.
  *   inQuoteCurrency {boolean} If true (default), converts all values to the quote currency first.
  *   
  */
 const Book = require('../../models/book');
 const { AleError, codes } = require('../errors');
+
+const checkAccountInQuery = require('../helpers/validateAccountInQuery')
+
+exports.middleware = checkAccountInQuery;
 
 exports.handler = function getBalance(req, res, next) {
     let id = parseInt(req.params.bookId);

--- a/lib/handlers/getTransactions.js
+++ b/lib/handlers/getTransactions.js
@@ -4,20 +4,24 @@
  * GET: /books/{bookId}/transactions
  * 
  * query:
- *   accounts {string} A comma-separated search term for accounts.
+ *   account {string} Name of account to return transactions for.
+ *   accountCode {number} Code of account to return transactions for.
  *   perPage {integer} The number of results per page.
  *   page {integer} The page number.
  *   
  */
 const Book = require('../../models/book');
-const {AleError, codes} = require('../errors');
+const { AleError, codes } = require('../errors');
+const checkAccountInQuery = require('../helpers/validateAccountInQuery')
+
+exports.middleware = checkAccountInQuery;
 exports.handler = function getTransactions(req, res, next) {
     let id = parseInt(req.params.bookId);
     Book.findById(id).then(book => {
         if (!book) {
             throw new AleError(`Book with id ${id} does not exist`, codes.BookDoesNotExist);
         }
-        const account = req.query.accounts.split(',');
+        const { account } = req.query.account;
         const { perPage, page } = req.query;
         return book.getTransactions({ account, perPage, page });
     }).then(txs => {

--- a/lib/handlers/postAccount.js
+++ b/lib/handlers/postAccount.js
@@ -11,7 +11,6 @@
  *   accountType {string}
  *   subAccountType {string}
  *   memo {string} Some description of the account.
- *   bookId {integer} Already created book for account to be linked to.
  *   
  */
 const { codes, AleError } = require('../errors');
@@ -44,7 +43,7 @@ exports.handler = function postAccount(req, res, next) {
         return res.json({
             success: true,
             message: 'New account has been created successfully',
-            id: e
+            account: e[0]
         });
     }).catch(err => {
         return next(err);

--- a/lib/handlers/postBookEntry.js
+++ b/lib/handlers/postBookEntry.js
@@ -11,23 +11,9 @@
  */
 const { codes, AleError } = require('../errors');
 const Book = require('../../models/book');
-const Account = require('../../models/Account');
+const checkAccount = require('../helpers/validateAccount')
 
 exports.middleware = checkAccount;
-
-function checkAccount(req, res, next) {
-
-    req.body.transactions.forEach((tx, i) => {
-        Account.findOne({ where: { accountName: tx.account } }).then(account => {
-            if (!account) {
-                throw new AleError(`Account specified in transaction ${i} does not exist`, codes.BookDoesNotExist);
-            }
-            return next();
-        }).catch(err => {
-            return next(err);
-        });
-    })
-};
 
 exports.handler = function postBookEntry(req, res, next) {
     let id = parseInt(req.params.bookId);
@@ -44,6 +30,8 @@ exports.handler = function postBookEntry(req, res, next) {
         }
         const newEntry = book.newJournalEntry(candidateEntry.memo, ts);
         candidateEntry.transactions.forEach((tx, i) => {
+            console.log('fx here');
+            
             const amount = parseFloat(tx.credit || 0) - parseFloat(tx.debit || 0);
             if (!isFinite(amount)) {
                 throw new AleError(`Invalid credit and/or debit amount for transaction ${i}`, codes.ValidationError);
@@ -51,9 +39,10 @@ exports.handler = function postBookEntry(req, res, next) {
             const isCredit = amount > 0;
             const absAmount = Math.abs(amount);
             const account = tx.account;
+            const accountCode = tx.accountCode;
             const exchangeRate = parseFloat(tx.exchangeRate) || 1.0;
             const currency = tx.currency || bookInfo.currency;
-            newEntry.newTransaction(account, absAmount, isCredit, currency, exchangeRate);
+            newEntry.newTransaction(account, accountCode, absAmount, isCredit, currency, exchangeRate);
         });
         return newEntry.commit();
     }).then(e => {

--- a/lib/helpers/validateAccount.js
+++ b/lib/helpers/validateAccount.js
@@ -1,0 +1,29 @@
+const Account = require('../../models/Account');
+
+async function checkAccount(req, res, next) {
+  let noError = true;
+
+  for (entry of req.body.transactions) {
+    const account = await Account.findOne({ where: { accountCode: entry.accountCode } });
+    if (!account) {
+      noError = false;
+      return res.status(404).json({
+        success: false,
+        message: `Account code ${entry.account} is not found.`,
+      })
+    }
+
+    if (account && account.accountName != entry.account) {
+      noError = false;
+      return res.status(400).json({
+        success: false,
+        message: `Account code ${entry.accountCode} does not match account name ${entry.account}`,
+      })
+    }
+  }
+  if (noError) {
+    return next();
+  }
+};
+
+module.exports = checkAccount;

--- a/lib/helpers/validateAccountInQuery.js
+++ b/lib/helpers/validateAccountInQuery.js
@@ -1,0 +1,29 @@
+const Account = require('../../models/Account');
+
+async function checkAccountInQuery(req, res, next) {
+  const { account, accountCode } = req.query;
+  let noError = true;
+
+  const result = await Account.findOne({ where: { accountCode } });
+  if (!result) {
+    noError = false;
+    return res.status(404).json({
+      success: false,
+      message: `Account code ${accountCode} is not found.`,
+    })
+  }
+
+  if (result && result.accountName != account) {
+    noError = false;
+    return res.status(400).json({
+      success: false,
+      message: `Account code ${accountCode} does not match account name ${account}`,
+    })
+  }
+
+  if (noError) {
+    return next();
+  }
+};
+
+module.exports = checkAccountInQuery;

--- a/models/account.js
+++ b/models/account.js
@@ -39,13 +39,13 @@ const Account = sequelize.define('account', {
  */
 Account.getOrCreateBook = function (accountCode, accountName, toIncrease, accountClassification, accountType, subAccountType, memo, bookId) {
   return Account.findOrCreate({
-    where: { accountCode: accountCode },
+    where: { $or: [{ accountCode }, { accountName }] },
     defaults: {
       accountCode, accountName, toIncrease, accountClassification, accountType, subAccountType, memo, bookId
     }
   }).then(result => {
     if (result.includes(false)) {
-      return sequelize.Promise.reject(new AleError('Account code already exists', codes.DatabaseQueryError));
+      return sequelize.Promise.reject(new AleError('Account code or name already exists', codes.DatabaseQueryError));
     }
     return result
   });
@@ -57,7 +57,7 @@ Account.getAccounts = function (id) {
       bookId: id
     }
   }).then(results => {
-    
+
     return results
   });
 };

--- a/models/book.js
+++ b/models/book.js
@@ -236,11 +236,10 @@ function parseQuery(id, query) {
     if ((account = query.account)) {
 
         if (account instanceof Array) {
-            let accountList = account.map(a => ({ [Op.like]: `${a}%` }));
-            parsed.where.account = { [Op.or]: accountList };
+            parsed.where.account = { [Op.or]: account };
         }
         else {
-            parsed.where.account = { [Op.like]: `${account}%` };
+            parsed.where.account = account ;
         }
         delete query.account;
     }

--- a/models/journal.js
+++ b/models/journal.js
@@ -14,18 +14,18 @@
 const Sequelize = require('sequelize');
 const sequelize = require('./connection');
 const Transaction = require('./transaction');
-const {NEAR_ZERO} = require('./types');
-const {AleError, codes} = require('../lib/errors');
+const { NEAR_ZERO } = require('./types');
+const { AleError, codes } = require('../lib/errors');
 
 /**
  * A journal entry comprises a set of transactions, which have a balance set of debit and credit entries
  */
 const JournalEntry = sequelize.define('journal', {
-        memo: {type: Sequelize.TEXT, defaultValue: ''},
-        timestamp: {type: Sequelize.DATE, validate: {isDate: true}, defaultValue: Date.now},
-        voided: {type: Sequelize.BOOLEAN, defaultValue: false},
-        voidReason: Sequelize.STRING
-    }, {
+    memo: { type: Sequelize.TEXT, defaultValue: '' },
+    timestamp: { type: Sequelize.DATE, validate: { isDate: true }, defaultValue: Date.now },
+    voided: { type: Sequelize.BOOLEAN, defaultValue: false },
+    voidReason: Sequelize.STRING
+}, {
         name: {
             singular: 'JournalEntry',
             plural: 'JournalEntries'
@@ -33,11 +33,11 @@ const JournalEntry = sequelize.define('journal', {
     }
 );
 
-Transaction.JournalEntry = Transaction.belongsTo(JournalEntry, {foreignKey: {allowNull: false}, onDelete: 'CASCADE'});
-JournalEntry.hasOne(JournalEntry, {as: 'Original'});
-JournalEntry.hasMany(Transaction, {foreignKey: {allowNull: false}, onDelete: 'CASCADE'});
+Transaction.JournalEntry = Transaction.belongsTo(JournalEntry, { foreignKey: { allowNull: false }, onDelete: 'CASCADE' });
+JournalEntry.hasOne(JournalEntry, { as: 'Original' });
+JournalEntry.hasMany(Transaction, { foreignKey: { allowNull: false }, onDelete: 'CASCADE' });
 
-JournalEntry.prototype.values = function() {
+JournalEntry.prototype.values = function () {
     return {
         id: this.getDataValue('id'),
         memo: this.getDataValue('memo'),
@@ -48,21 +48,21 @@ JournalEntry.prototype.values = function() {
     };
 };
 
-JournalEntry.prototype.voidEntry = function(book, reason) {
+JournalEntry.prototype.voidEntry = function (book, reason) {
     if (this.voided === true) {
         return sequelize.Promise.reject(new Error('Journal entry already voided'));
     }
-    return sequelize.transaction({autocommit: false}, t => {
+    return sequelize.transaction({ autocommit: false }, t => {
         // Set this to void with reason and also set all associated transactions
         this.voided = true;
         this.voidReason = !reason ? '' : reason;
-        return this.save({transaction: t}).then(oldEntry => {
+        return this.save({ transaction: t }).then(oldEntry => {
             return oldEntry.getTransactions();
         }).then(txs => {
             return sequelize.Promise.map(txs, tx => {
                 tx.voided = true;
                 tx.voidReason = reason;
-                return tx.save({transaction: t});
+                return tx.save({ transaction: t });
             });
         }).then(txs => {
             let newMemo = `${this.memo} [REVERSED]`;
@@ -92,20 +92,21 @@ JournalEntry.prototype.voidEntry = function(book, reason) {
     });
 };
 
-JournalEntry.prototype.newTransaction = function(account, amount, isCredit, currency, exchangeRate = 1.0) {
+JournalEntry.prototype.newTransaction = function (account, accountCode, amount, isCredit, currency, exchangeRate = 1.0) {
     amount = +amount;
     if (typeof account === 'string') {
         account = account.split(':');
     }
-    
+
     if (account.length > 3) {
         const err = new Error('Account path is too deep (maximum 3)');
         err.accountPath = account;
         throw err;
     }
-    
+
     const transaction = Transaction.build({
         account: account.join(':'),
+        accountCode: accountCode,
         credit: isCredit ? amount : 0.0,
         debit: isCredit ? 0.0 : amount,
         exchangeRate: +exchangeRate,
@@ -117,24 +118,24 @@ JournalEntry.prototype.newTransaction = function(account, amount, isCredit, curr
         this.pendingTransactions = [];
     }
     this.pendingTransactions.push(transaction);
-    
+
     return this;
 };
 
-JournalEntry.prototype.debit = function(account, amount, currency = undefined, exchangeRate = 1.0) {
-    return this.newTransaction(account, amount, false, currency, exchangeRate);
+JournalEntry.prototype.debit = function (account, accountCode, amount, currency = undefined, exchangeRate = 1.0) {
+    return this.newTransaction(account, accountCode, amount, false, currency, exchangeRate);
 };
 
-JournalEntry.prototype.credit = function(account, amount, currency = undefined, exchangeRate = 1.) {
-    return this.newTransaction(account, amount, true, currency, exchangeRate);
+JournalEntry.prototype.credit = function (account, accountCode, amount, currency = undefined, exchangeRate = 1.) {
+    return this.newTransaction(account, accountCode, amount, true, currency, exchangeRate);
 };
 
-JournalEntry.prototype.commit = function() {
+JournalEntry.prototype.commit = function () {
     const total = this.calculatePendingTotal();
     if (Math.abs(total) > NEAR_ZERO) {
         return sequelize.Promise.reject(new AleError('Invalid Journal Entry. Total not zero', codes.EntryNotBalanced));
     }
-    return sequelize.transaction({autocommit: false}, t => {
+    return sequelize.transaction({ autocommit: false }, t => {
         return this._saveEntryWithTxs(t);
     }).then(result => {
         // Transaction has committed
@@ -146,18 +147,18 @@ JournalEntry.prototype.commit = function() {
     });
 };
 
-JournalEntry.prototype._saveEntryWithTxs = function(t) {
+JournalEntry.prototype._saveEntryWithTxs = function (t) {
     let result;
-    return this.save({transaction: t}).then(e => {
+    return this.save({ transaction: t }).then(e => {
         result = e;
         const id = result.getDataValue('id');
-        return this.saveTransactions(id, {transaction: t});
+        return this.saveTransactions(id, { transaction: t });
     }).then(() => {
         return sequelize.Promise.resolve(result);
     });
 };
 
-JournalEntry.prototype.calculatePendingTotal = function(txs) {
+JournalEntry.prototype.calculatePendingTotal = function (txs) {
     const transactions = txs || this.pendingTransactions;
     if (!transactions || !Array.isArray(transactions) || transactions.length === 0) {
         return;
@@ -170,7 +171,7 @@ JournalEntry.prototype.calculatePendingTotal = function(txs) {
     return total;
 };
 
-JournalEntry.prototype.saveTransactions = function(id, opts) {
+JournalEntry.prototype.saveTransactions = function (id, opts) {
     const transactions = this.pendingTransactions;
     return sequelize.Promise.map(transactions, tx => {
         tx.setDataValue('JournalEntryId', id);

--- a/models/transaction.js
+++ b/models/transaction.js
@@ -25,6 +25,7 @@ Transaction = sequelize.define('transaction', {
     exchangeRate: { type: CURRENCY_LARGE, validate: { isDecimal: true }, defaultValue: 1.0 },
     currency: { type: Sequelize.STRING, defaultValue: 'USD', notNull: true },
     account: Sequelize.STRING,
+    accountCode: Sequelize.INTEGER,
     timestamp: { type: Sequelize.DATE, validate: { isDate: true }, default: Date.now },
     voided: { type: Sequelize.BOOLEAN, default: false },
     voidReason: Sequelize.STRING,

--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -207,7 +207,7 @@ paths:
         200:
           description: Success
           schema:
-            $ref: '#/definitions/Response'
+            $ref: '#/definitions/NewAccountResponse'
 
   '/books/{bookId}/transactions':
     parameters:
@@ -220,10 +220,16 @@ paths:
       summary: List all transactions for given accounts
       operationId: getTransactions
       parameters:
-      - name: accounts
-        description: A comma-separated search term for accounts
+      - name: account
+        description: Name of account to return transactions for
         in: query
         type: string
+        required: true
+
+      - name: accountCode
+        description: Code of account to return transactions for
+        in: query
+        type: number
         required: true
 
       - name: perPage
@@ -260,7 +266,12 @@ paths:
       operationId: getBalance
       parameters:
       - name: account
-        description: The account to get the balance for
+        description: The account name to get the balance for
+        in: query
+        type: string
+        required: true
+      - name: accountCode
+        description: The account code to get the balance for
         in: query
         type: string
         required: true
@@ -418,10 +429,14 @@ definitions:
     type: object
     required:
       - account
+      - accountCode
     properties:
       account:
-        description: The account this transaction is reflected on
+        description: The account name this transaction is reflected on
         type: string
+      accountCode:
+        description: The account code this transaction is reflected on
+        type: number
       credit:
         description: The credit value of the transaction
         type: number
@@ -487,7 +502,6 @@ definitions:
       - accountCode
       - accountName
       - toIncrease
-      - bookId
     properties:
       accountCode:
         description: Unique code for the new account
@@ -510,9 +524,19 @@ definitions:
       memo:
         description: Some description of the account
         type: string
-      bookId:
-        description: Already created book for account to be linked to
-        type: integer
+
+  NewAccountResponse:
+    type: object
+    properties:
+      success:
+        description: Indicates whether request was succesful
+        type: boolean
+      message:
+        description: Short elaboration of status
+        type: string
+      account:
+        description: New account created object
+        type: object
 
   Balance:
     type: object


### PR DESCRIPTION
Added the following changes:
- refactored code to require both account name and account code when posting new entry
- refactored code to require both account name and account code when getting single account balance
- refactor to remove returning account balance for similar accounts in get account balance, no similar account query
- require account code in get transactions for a single account and remove getting balance for multiple account at once
- refactor create new account to not require bookId and check if eithet account name or code exists